### PR TITLE
POSIX fixes for standard C compatibility

### DIFF
--- a/include/cutest.h
+++ b/include/cutest.h
@@ -167,16 +167,16 @@ test_print_in_color__(int color, const char* fmt, ...)
     {
         const char* col_str;
         switch(color) {
-            case CUTEST_COLOR_GREEN__:             col_str = "\e[0;32m"; break;
-            case CUTEST_COLOR_RED__:               col_str = "\e[0;31m"; break;
-            case CUTEST_COLOR_GREEN_INTENSIVE__:   col_str = "\e[1;32m"; break;
-            case CUTEST_COLOR_RED_INTENSIVE__:     col_str = "\e[1;30m"; break;
-            case CUTEST_COLOR_DEFAULT_INTENSIVE__: col_str = "\e[1m"; break;
-            default:                               col_str = "\e[0m"; break;
+            case CUTEST_COLOR_GREEN__:             col_str = "\033[0;32m"; break;
+            case CUTEST_COLOR_RED__:               col_str = "\033[0;31m"; break;
+            case CUTEST_COLOR_GREEN_INTENSIVE__:   col_str = "\033[1;32m"; break;
+            case CUTEST_COLOR_RED_INTENSIVE__:     col_str = "\033[1;30m"; break;
+            case CUTEST_COLOR_DEFAULT_INTENSIVE__: col_str = "\033[1m"; break;
+            default:                               col_str = "\033[0m"; break;
         }
         printf("%s", col_str);
         n = printf("%s", buffer);
-        printf("\e[0m");
+        printf("\033[0m");
         return n;
     }
 #elif defined CUTEST_WIN__

--- a/include/cutest.h
+++ b/include/cutest.h
@@ -88,13 +88,13 @@
 
 /* The unit test files should not rely on anything below. */
 
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
     #define CUTEST_UNIX__    1
+    /* CUTEST_UNIX__ assumes POSIX.1-1990 or later is available */
+    #ifndef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 1
+    #endif
     #include <errno.h>
     #include <unistd.h>
     #include <sys/types.h>
@@ -102,6 +102,11 @@
     #include <signal.h>
 #endif
 
+/* _POSIX_C_SOURCE must be defined before these includes */
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
     #define CUTEST_WIN__     1
     #include <windows.h>


### PR DESCRIPTION
Thanks for your handy test header. It is both lightweight and useful!

This pull request contains two commits:

- One commit replaces "\e" by its octal equivalent "\033". "\e" is a GNU extension and does not belong to the ISO C standard. [Ref](https://en.wikipedia.org/wiki/Escape_sequences_in_C#Non-standard_escape_sequences)

- The other commit defines (if it is not defined) `_POSIX_C_SOURCE` as required by `man fileno` and moves the inclusion of some standard headers after the definition of `_POSIX_C_SOURCE` as required by `man feature_test_macros`. `cutest.h` has been assuming that if unix or APPLE is defined, then POSIX headers are available. This is false if for instance the `-ansi` flag is passed to the gcc compiler or if the `--std=c99` flag is used. By defining `_POSIX_C_SOURCE` we make sure the POSIX headers are available.
